### PR TITLE
Replace OWNER placeholder with sl1nki

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,10 +1,10 @@
-See [CHANGELOG.md](https://github.com/OWNER/terraform-aws-go-lambda/blob/main/CHANGELOG.md) for detailed release notes.
+See [CHANGELOG.md](https://github.com/sl1nki/terraform-aws-go-lambda/blob/main/CHANGELOG.md) for detailed release notes.
 
 ## Installation
 
 ```hcl
 module "go_lambda" {
-  source = "git::https://github.com/OWNER/terraform-aws-go-lambda.git?ref=VERSION"
+  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=VERSION"
 
   prefix       = "myapp"
   name         = "handler"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,5 +34,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Input validation for all constrained variables
 - Secure build script with proper error handling and quoting
 
-[Unreleased]: https://github.com/OWNER/terraform-aws-go-lambda/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/OWNER/terraform-aws-go-lambda/releases/tag/v1.0.0
+[Unreleased]: https://github.com/sl1nki/terraform-aws-go-lambda/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/sl1nki/terraform-aws-go-lambda/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Reusable OpenTofu/Terraform module for deploying Go Lambda functions on AWS with
 
 ```hcl
 module "lambda_orders" {
-  source = "git::https://github.com/OWNER/terraform-aws-go-lambda.git?ref=v1.0.0"
+  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=v1.0.0"
 
   prefix       = "myproject"
   name         = "orders"
@@ -51,7 +51,7 @@ module "lambda_orders" {
 
 ```hcl
 module "lambda_secure" {
-  source = "git::https://github.com/OWNER/terraform-aws-go-lambda.git?ref=v1.0.0"
+  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=v1.0.0"
 
   prefix       = "myproject"
   name         = "secure-api"
@@ -86,7 +86,7 @@ module "lambda_secure" {
 
 ```hcl
 module "my_lambda" {
-  source = "git::https://github.com/OWNER/terraform-aws-go-lambda.git?ref=v1.0.0"
+  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=v1.0.0"
 
   function_name = "${var.env}-my-function"
   iam_role_arn  = aws_iam_role.lambda_exec.arn


### PR DESCRIPTION
## Summary

Replaces the `OWNER` placeholder in documentation files with `sl1nki` for correct repository URLs.

Files updated:
- README.md
- CHANGELOG.md
- .github/release-body.md