### PR TITLE
Update documentation to use Terraform Registry

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -2,14 +2,27 @@ See [CHANGELOG.md](https://github.com/sl1nki/terraform-aws-go-lambda/blob/main/C
 
 ## Installation
 
+**Terraform Registry** (recommended):
+
 ```hcl
 module "go_lambda" {
-  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=VERSION"
+  source  = "sl1nki/go-lambda/aws"
+  version = "~> 1.1"
 
   prefix       = "myapp"
   name         = "handler"
   source_path  = "cmd/handler"
   project_root = path.root
   environment  = "production"
+}
+```
+
+**Direct from GitHub**:
+
+```hcl
+module "go_lambda" {
+  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=VERSION"
+
+  # ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # terraform-aws-go-lambda
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Terraform Registry](https://img.shields.io/badge/Terraform%20Registry-sl1nki%2Fgo--lambda%2Faws-blue)](https://registry.terraform.io/modules/sl1nki/go-lambda/aws)
 
 Reusable OpenTofu/Terraform module for deploying Go Lambda functions on AWS with production-ready security features.
 
@@ -29,7 +30,8 @@ Reusable OpenTofu/Terraform module for deploying Go Lambda functions on AWS with
 
 ```hcl
 module "lambda_orders" {
-  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=v1.0.0"
+  source  = "sl1nki/go-lambda/aws"
+  version = "~> 1.1"
 
   prefix       = "myproject"
   name         = "orders"
@@ -51,7 +53,8 @@ module "lambda_orders" {
 
 ```hcl
 module "lambda_secure" {
-  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=v1.0.0"
+  source  = "sl1nki/go-lambda/aws"
+  version = "~> 1.1"
 
   prefix       = "myproject"
   name         = "secure-api"
@@ -86,7 +89,8 @@ module "lambda_secure" {
 
 ```hcl
 module "my_lambda" {
-  source = "git::https://github.com/sl1nki/terraform-aws-go-lambda.git?ref=v1.0.0"
+  source  = "sl1nki/go-lambda/aws"
+  version = "~> 1.1"
 
   function_name = "${var.env}-my-function"
   iam_role_arn  = aws_iam_role.lambda_exec.arn


### PR DESCRIPTION
## Summary

Updates documentation to reference the Terraform Registry now that the module is published.

Changes:
- Add Terraform Registry badge to README
- Update all example `source` references to use registry format (`sl1nki/go-lambda/aws`)
- Add `version` constraint to examples (`~> 1.1`)
- Update release body template with registry as recommended installation method