### PR TITLE
Fix for_each failure when policy ARN is unknown at plan time

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -55,10 +55,12 @@ resource "aws_iam_role_policy_attachment" "lambda_xray" {
 }
 
 # Additional policy attachments
+# Uses count instead of for_each so that unknown ARNs (e.g. a policy created
+# in the same apply) don't block planning. length() is plan-time-safe.
 resource "aws_iam_role_policy_attachment" "additional" {
-  for_each   = var.iam_role_arn == null ? toset(var.additional_policy_arns) : toset([])
+  count      = var.iam_role_arn == null ? length(var.additional_policy_arns) : 0
   role       = aws_iam_role.lambda[0].name
-  policy_arn = each.value
+  policy_arn = var.additional_policy_arns[count.index]
 }
 
 # Optional inline policy


### PR DESCRIPTION
# Description

Replace `for_each` with `count` on `aws_iam_role_policy_attachment.additional` so that policies created in the same apply don't cause a plan-time failure.

`for_each` requires all set keys to be known at plan time, which fails when a new `aws_iam_policy` resource produces an unknown ARN. `count = length(...)` only needs the list size, which is always known.

Trade-off: reordering or removing items from the middle of the policy list causes downstream attachments to be recreated. This is acceptable since policy attachments are stateless.

# Testing

- `tofu validate` passes
- All pre-commit and pre-push hooks pass