### PR TITLE
Drop pipefail from local-exec provisioner for dash compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "terraform_data" "lambda_zip" {
 
   provisioner "local-exec" {
     command = <<-EOF
-      set -euo pipefail
+      set -eu
       mkdir -p "${local.build_dir}"
       cd "${local.go_src_path}"
       GOOS=linux GOARCH="${local.goarch}" go build -tags lambda.norpc -o "${local.build_dir}/bootstrap" "./${var.source_path}/"


### PR DESCRIPTION
## Description

The `local-exec` provisioner runs under `/bin/sh`, which is `dash` on Ubuntu (GitHub Actions runners). Dash does not support `pipefail`. Since the script contains no pipe operators (only `&&` chaining), `set -eu` provides full error protection.

Fixes deploy failures in downstream consumers running `tofu apply` on GitHub Actions.

## Testing

- Verified the provisioner script contains zero `|` operators
- `set -eu` still catches: unset variables (`-u`), non-zero exits (`-e`)