### PR TITLE
ci: add workflow to fix Dependabot docs failures

### DIFF
--- a/.github/workflows/dependabot-docs.yml
+++ b/.github/workflows/dependabot-docs.yml
@@ -1,0 +1,73 @@
+name: Fix Dependabot Docs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  fix-docs:
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      startsWith(github.head_ref, 'dependabot/terraform/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 10
+
+      - name: Check retry limit
+        id: retries
+        run: |
+          count=$(git log --oneline --grep='\[dependabot skip\] docs: regenerate' | wc -l | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [ "$count" -ge 2 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Retry limit (2) reached for docs fix on this PR"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run terraform-docs
+        if: steps.retries.outputs.skip != 'true'
+        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
+        with:
+          working-dir: .
+          output-file: README.md
+          output-method: inject
+          fail-on-diff: false
+
+      - name: Check for diff
+        if: steps.retries.outputs.skip != 'true'
+        id: diff
+        run: |
+          if git diff --quiet README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate GitHub App token
+        if: steps.retries.outputs.skip != 'true' && steps.diff.outputs.changed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Commit and push docs update
+        if: steps.retries.outputs.skip != 'true' && steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git add README.md
+          git commit -m "[dependabot skip] docs: regenerate README.md"
+          git push


### PR DESCRIPTION
# Description

Adds a `Fix Dependabot Docs` workflow that automatically regenerates `README.md` when Dependabot opens terraform PRs. This fixes the recurring CI failure where Dependabot updates `versions.tf` but doesn't regenerate docs, causing the "Documentation Check" job to fail with `fail-on-diff: true`.

**How it works:**
- Triggers on `pull_request_target` (opened/synchronize) for `dependabot[bot]` actor only
- Scoped to `dependabot/terraform/` branches (github-actions PRs don't affect docs)
- Runs `terraform-docs` to regenerate `README.md`, commits and pushes if changed
- Uses a GitHub App token so the push triggers CI re-runs (unlike `GITHUB_TOKEN`)
- Includes a retry limit (2) to prevent runaway loops
- Loop-safe: second run finds no diff and exits cleanly

**Secrets required** (already set):
- `APP_ID` — GitHub App numeric ID
- `APP_PRIVATE_KEY` — GitHub App private key

# Testing

- Merge this PR, then close/reopen PR #17 (or wait for next Dependabot terraform PR)
- Verify the workflow runs, commits the README fix, and CI passes on re-run