### PR TITLE
fix: check staged diff in dependabot-docs workflow

### DIFF
--- a/.github/workflows/dependabot-docs.yml
+++ b/.github/workflows/dependabot-docs.yml
@@ -46,7 +46,7 @@ jobs:
         if: steps.retries.outputs.skip != 'true'
         id: diff
         run: |
-          if git diff --quiet README.md; then
+          if git diff --staged --quiet README.md; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

The terraform-docs action internally runs `git add` which stages changes. The diff check was using `git diff --quiet` which only checks unstaged changes, so it never detected the README update. Changed to `git diff --staged --quiet` to check the index instead.

# Testing

Merge, then trigger `@dependabot recreate` on PR #17.