### PR TITLE
fix: reclaim file ownership after terraform-docs docker step

### DIFF
--- a/.github/workflows/dependabot-docs.yml
+++ b/.github/workflows/dependabot-docs.yml
@@ -42,6 +42,10 @@ jobs:
           output-method: inject
           fail-on-diff: false
 
+      - name: Fix ownership
+        if: steps.retries.outputs.skip != 'true'
+        run: sudo chown -R "$(id -u):$(id -g)" .
+
       - name: Check for diff
         if: steps.retries.outputs.skip != 'true'
         id: diff


### PR DESCRIPTION
# Description

The terraform-docs GitHub Action runs as a Docker container (root), which changes ownership of `.git/objects`. The subsequent `git add`/`git commit` as the runner user then fails with `insufficient permission for adding an object to repository database`.

Adds `sudo chown -R` after the Docker step to reclaim ownership before committing.