### PR TITLE
ci: use dependabot-fixer bot identity for docs fix commits

### DIFF
--- a/.github/workflows/dependabot-docs.yml
+++ b/.github/workflows/dependabot-docs.yml
@@ -69,8 +69,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "sl1nki-dependabot-fixer[bot]"
+          git config user.email "263205248+sl1nki-dependabot-fixer[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git add README.md
           git commit -m "[dependabot skip] docs: regenerate README.md"


### PR DESCRIPTION
# Description

Updates the git committer identity in the dependabot-docs workflow from generic `github-actions[bot]` to `sl1nki-dependabot-fixer[bot]`, matching the GitHub App that powers the workflow.