### PR TITLE
ci: dispatch CI after dependabot docs auto-fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-docs.yml
+++ b/.github/workflows/dependabot-docs.yml
@@ -78,3 +78,12 @@ jobs:
           git add README.md
           git commit -m "[dependabot skip] docs: regenerate README.md"
           git push
+
+      - name: Re-run CI on the new commit
+        if: steps.retries.outputs.skip != 'true' && steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh workflow run ci.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.event.pull_request.head.ref }}"


### PR DESCRIPTION
# Description
When the `Fix Dependabot Docs` workflow regenerates README.md and pushes it to a Dependabot PR, the new commit doesn't trigger CI. This leaves PRs stuck with stale failing CI status (e.g. PR #44).

Two changes:
- Add `workflow_dispatch` to `ci.yml` so the workflow can be triggered manually.
- After the docs auto-fix pushes, dispatch `ci.yml` against the PR's head ref using the same App token that pushed the commit.

# Testing
- [ ] Merge, then close+reopen PR #44 (or wait for next dependabot terraform PR) and confirm CI runs on the auto-fix commit.