### PR TITLE
ci: auto-merge dependabot PRs and re-trigger CI after docs regen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,41 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr merge --auto --squash --repo "${{ github.repository }}" "$PR_NUMBER"
+
+  update-behind-prs:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update open dependabot PRs that are behind main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr list \
+            --repo "${{ github.repository }}" \
+            --author "app/dependabot" \
+            --state open \
+            --json number,mergeStateStatus \
+            --jq '.[] | select(.mergeStateStatus == "BEHIND") | .number' \
+          | while read -r n; do
+              echo "Updating PR #$n"
+              gh api -X PUT "repos/${{ github.repository }}/pulls/$n/update-branch" || true
+            done

--- a/.github/workflows/dependabot-docs.yml
+++ b/.github/workflows/dependabot-docs.yml
@@ -78,3 +78,12 @@ jobs:
           git add README.md
           git commit -m "[dependabot skip] docs: regenerate README.md"
           git push
+
+      - name: Re-run CI on the docs-fix commit
+        if: steps.retries.outputs.skip != 'true' && steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh workflow run ci.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.event.pull_request.head.ref }}"


### PR DESCRIPTION
# Description

Closes the gap that left dependabot PRs needing manual intervention to land. Three changes:

1. **`ci.yml`**: Add `workflow_dispatch` trigger so the docs-fix workflow can re-run CI on a branch after pushing the regen commit.
2. **`dependabot-docs.yml`**: After the App-token push that regenerates `README.md`, explicitly dispatch `ci.yml` against the PR branch. Pushes by GitHub Apps do not always re-fire `pull_request` workflows, which previously left PRs with required checks pointing at the pre-fix SHA.
3. **`dependabot-automerge.yml`** (new):
   - On dependabot PR `opened`/`synchronize`/`reopened`/`ready_for_review`: enable squash auto-merge via `gh pr merge --auto --squash`. GitHub merges the PR as soon as required checks pass.
   - On `push` to `main`: scan open dependabot PRs and call `update-branch` on any that are `BEHIND`, so branch protection's `strict` requirement is satisfied automatically when other PRs merge first.

# Testing

- [ ] Next dependabot terraform PR opens, docs workflow runs and re-dispatches CI, auto-merge fires once checks are green
- [ ] When two dependabot PRs are open and one merges, the other auto-updates and merges on its own