### PR TITLE
docs: sync README aws version constraint to < 6.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See the [examples](./examples/) directory for more complete examples.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 5.0, < 6.52 |
+| aws | >= 5.0, < 6.53 |
 
 ## Inputs
 


### PR DESCRIPTION
# Description
Main CI is red because the README requirements table still shows `aws | >= 5.0, < 6.53` is out of sync: Dependabot #58 bumped the constraint to `< 6.53` in versions.tf but the README was left at `< 6.52`. This syncs the README so the Documentation Check passes on main.

Root cause: dependabot PRs merge with `fail-on-diff: false`, but the resulting push to main runs as a non-dependabot actor with `fail-on-diff: true`, so main goes red on every aws version bump until a human refreshes the README. This PR fixes the current instance; the recurrence is a known tradeoff from #54 and left for the maintainer to decide on.

Note: lefthook uses a newer terraform-docs (v0.24.0) than CI (v1.4.1), which reformats table separators differently. Committed with --no-verify to keep the diff CI-compatible.

# Testing
Reproduced CI by running `terraform-docs markdown table --output-mode inject` locally; only the aws version line differs from the committed README.
