### PR TITLE
docs: regenerate README terraform-docs for aws constraint bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See the [examples](./examples/) directory for more complete examples.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 5.0, < 6.52 |
+| aws | >= 5.0, < 6.53 |
 
 ## Inputs
 


### PR DESCRIPTION
# Description
The CI Documentation Check failed on main because dependabot PR #58 bumped the AWS provider constraint in `versions.tf` (`< 6.52` → `< 6.53`) without regenerating the terraform-docs README table. This regenerates README.md to match.

# Testing
Regenerated via the same terraform-docs version CI uses (v0.20.0, `quay.io/terraform-docs/gh-actions:1.4.1`); only the Requirements table version line changes.