### PR TITLE
docs: sync README requirements table with aws < 6.53 constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See the [examples](./examples/) directory for more complete examples.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 5.0, < 6.52 |
+| aws | >= 5.0, < 6.53 |
 
 ## Inputs
 


### PR DESCRIPTION
# Description
The CI Documentation Check on main fails with `Uncommitted change(s) has been found!` because the terraform-docs requirements table in README.md still shows `aws >= 5.0, < 6.52` while versions.tf was bumped to `< 6.53` by dependabot #58. The docs job skips `fail-on-diff` for dependabot PRs, but the post-merge push-to-main event runs as a non-dependabot actor and fails on the stale table.

This syncs the README table to match versions.tf, restoring a green main.

# Testing
Edited only the version line, preserving the compact terraform-docs 1.4.1 separator style so the CI inject produces no diff.