### PR TITLE
docs: refresh README aws provider version to match versions.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See the [examples](./examples/) directory for more complete examples.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 5.0, < 6.52 |
+| aws | >= 5.0, < 6.54 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See the [examples](./examples/) directory for more complete examples.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 5.0, < 6.54 |
+| aws | >= 5.0, < 6.55 |
 
 ## Inputs
 


### PR DESCRIPTION
# Description
The auto-generated Requirements table in README.md drifted from `versions.tf`: recent dependabot merges bumped the AWS provider constraint to `>= 5.0, < 6.54` (#63) while the README still showed `< 6.52`. The `Documentation Check` CI job (terraform-docs `fail-on-diff`) has been red on main as a result.

This refreshes the stale version line to match what the CI terraform-docs action regenerates.

# Testing
Reproduced CI exactly with the `terraform-docs/gh-actions:1.4.1` image (terraform-docs v0.20.0) on a clean checkout — regeneration now produces no diff. CI Documentation Check passes.
