### PR TITLE
ci: authenticate tflint --init to avoid GitHub rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
 
       - name: Initialize TFLint
         run: tflint --init
+        env:
+          # Authenticate plugin downloads to avoid GitHub API rate limits
+          # (unauthenticated requests share the runner IP's low quota).
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run TFLint
         run: tflint --recursive --format compact


### PR DESCRIPTION
# Description
The CI `TFLint` job intermittently fails at `tflint --init` with `403 API rate limit exceeded` while downloading the `tflint-ruleset-aws` plugin from the GitHub API. The step runs unauthenticated, so it uses the runner IP's shared, low unauthenticated quota.

This passes `GITHUB_TOKEN: ${{ github.token }}` to the init step. tflint uses it to authenticate plugin downloads, which lifts the rate limit.

# Testing
CI on this branch exercises the same `Initialize TFLint` step; a green run confirms authenticated plugin download works.
