### PR TITLE
ci: force tflint aws plugin PGP signature to avoid attestation init panic

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -4,9 +4,10 @@ plugin "terraform" {
 }
 
 plugin "aws" {
-  enabled = true
-  version = "0.35.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+  enabled   = true
+  version   = "0.35.0"
+  source    = "github.com/terraform-linters/tflint-ruleset-aws"
+  signature = "pgp"
 }
 
 # Naming conventions


### PR DESCRIPTION
# Description

`tflint --init` panics during the TFLint CI job while installing the `aws` ruleset plugin:

```
Installing "aws" plugin...
Panic: runtime error: invalid memory address or nil pointer dereference
 -> github.com/sigstore/sigstore-go/pkg/bundle.(*Bundle).TlogEntries
 -> github.com/sigstore/sigstore-go/pkg/verify.VerifyTlogEntry
```

The plugin block used `signature = "auto"` (the default), which prefers GitHub artifact-attestation (keyless/sigstore) verification whenever a token is present. A malformed/partial attestation bundle trips a nil-pointer deref in tflint 0.63.1's bundled `sigstore-go` — see terraform-linters/tflint#2591. This is deterministic (reproduced across two runs) and independent of any module change; the same TFLint + pinned aws 0.35.0 passed on main on 2026-07-12 before the upstream attestation regression surfaced.

Setting `signature = "pgp"` forces the working PGP verification path instead of the broken attestation path. The download stays authenticated (no unauthenticated GitHub API rate-limit risk) and signature verification remains enabled — it is not disabled.

Fixes: https://github.com/terraform-linters/tflint/issues/2591

# Testing
- Pre-push lefthook checks passed.
- CI on this branch exercises `tflint --init` + `tflint --recursive`.
