### PR TITLE
ci: only enforce docs fail-on-diff on human pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,14 @@ jobs:
           # left the PR's head SHA permanently uncovered and BLOCKED. The README
           # requirements table is refreshed on the next human commit (enforced
           # by lefthook). See removed dependabot-docs.yml workflow.
-          fail-on-diff: ${{ github.actor != 'dependabot[bot]' }}
+          #
+          # Only gate human-authored pull requests. On push to main the code is
+          # already merged, so a stale README (e.g. right after a Dependabot
+          # auto-merge) can't be fixed by failing here -- it just leaves main
+          # red until the next human commit. The push-to-main actor is the
+          # auto-merge bot, not dependabot[bot], so the actor check alone does
+          # not suppress it.
+          fail-on-diff: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
 
   security:
     name: Security Scan

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See the [examples](./examples/) directory for more complete examples.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 5.0, < 6.56 |
+| aws | >= 5.0, < 6.57 |
 
 ## Inputs
 


### PR DESCRIPTION
# Description
The Documentation Check job failed on the push-to-main run for #71 (the auto-merged Dependabot aws constraint bump). Root cause: the existing guard `fail-on-diff: ${{ github.actor != 'dependabot[bot]' }}` only suppresses failures on Dependabot PRs, but the push-to-main event after auto-merge runs as `sl1nki-maestro[bot]` (the auto-merge actor), so `fail-on-diff` evaluates true and the job fails on the just-merged commit's stale README.

The module already documents (in the job comment) that main's README is intentionally refreshed only on the next human commit via lefthook. Failing CI on that accepted state is pure noise and can't be acted on -- the code is already merged. This scopes `fail-on-diff` to human-authored `pull_request` events, which is the only place the gate is actionable. Human PRs still enforce a fresh README; Dependabot PRs and all pushes to main no longer fail.

Supersedes the stale README-sync attempts in #60, #61, #62 (all pinned to the old `< 6.53` constraint), which only patch one bump and go stale on the next.

# Testing
Workflow-only change; validated the `fail-on-diff` expression scopes to `github.event_name == 'pull_request'`.