### PR TITLE
ci: pass GITHUB_TOKEN to tflint --init to avoid plugin fetch rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Initialize TFLint
         run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run TFLint
         run: tflint --recursive --format compact

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See the [examples](./examples/) directory for more complete examples.
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 5.0, < 6.57 |
+| aws | >= 5.0, < 6.58 |
 
 ## Inputs
 


### PR DESCRIPTION
# Description

`tflint --init` fetches the AWS ruleset plugin from the GitHub API unauthenticated, so it intermittently fails with `403 API rate limit exceeded` (shared-IP limit on hosted runners). This blocks the TFLint check — most visibly on Dependabot PRs like #75.

Passing `GITHUB_TOKEN` to the init step makes the plugin fetch authenticated, which uses the much higher per-token rate limit. The token is available on Dependabot events (read-only is sufficient for release lookups).

# Testing

CI TFLint job on this branch exercises the change.
